### PR TITLE
Change navigate name to route

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To add your screen to the `NavHost`:
 ```[kotlin]
    setContent {
       val navigationController: NavHostController = rememberNavController()
-      NavHost(navController = navigationController, startDestination = Router.default.route) {
+      NavHost(navController = navigationController, startDestination = Router.default.url) {
         composable(Router.default) {
           Default(navigationController = navigationController)
         }
@@ -31,7 +31,7 @@ To add your screen to the `NavHost`:
 To navigate from one screen to another:
 
 ```[kotlin]
-navigationController.navigate(Router.sample.navigate("a", "b", "c"))
+navigationController.navigate(Router.sample.route("a", "b", "c"))
 ```
 
 For more examples you can check out our sample app.

--- a/app/src/main/java/com/xmartlabs/typednavigation/MainActivity.kt
+++ b/app/src/main/java/com/xmartlabs/typednavigation/MainActivity.kt
@@ -20,7 +20,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val navigationController: NavHostController = rememberNavController()
-            NavHost(navController = navigationController, startDestination = Router.default.route) {
+            NavHost(navController = navigationController, startDestination = Router.default.url) {
                 composable(Router.default) {
                     Default(navigationController = navigationController)
                 }
@@ -40,10 +40,10 @@ fun Default(navigationController: NavHostController) = Row(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.SpaceEvenly
 ) {
-    Button(onClick = { navigationController.navigate(Router.home.navigate("asd", 5)) }) {
+    Button(onClick = { navigationController.navigate(Router.home.route("asd", 5)) }) {
         Text(text = "Home")
     }
-    Button(onClick = { navigationController.navigate(Router.sample.navigate("a", "b", "c")) }) {
+    Button(onClick = { navigationController.navigate(Router.sample.route("a", "b", "c")) }) {
         Text(text = "Sample")
     }
 

--- a/typednavigation/src/main/java/com/xmartlabs/typednavigation/NavGraphBuilderExtensions.kt
+++ b/typednavigation/src/main/java/com/xmartlabs/typednavigation/NavGraphBuilderExtensions.kt
@@ -9,7 +9,7 @@ fun NavGraphBuilder.composable(
         function: @Composable () -> Unit
 ) {
     composable(
-            screen.route,
+            screen.url,
             screen.navArguments
     ) {
         function()
@@ -21,7 +21,7 @@ fun <A> NavGraphBuilder.composable(
         function: @Composable (A) -> Unit
 ) {
     composable(
-            screen.route,
+            screen.url,
             screen.navArguments
     ) {
         val arg1 = it.arguments?.get("a1") as A
@@ -34,7 +34,7 @@ fun <A1, A2> NavGraphBuilder.composable(
         function: @Composable (A1, A2) -> Unit
 ) {
     composable(
-            screen.route,
+            screen.url,
             screen.navArguments
     ) {
         val arg1 = it.arguments?.get("a1") as A1
@@ -48,7 +48,7 @@ fun <A1, A2, A3> NavGraphBuilder.composable(
         function: @Composable (A1, A2, A3) -> Unit
 ) {
     composable(
-            screen.route,
+            screen.url,
             screen.navArguments
     ) {
         val arg1 = it.arguments?.get("a1") as A1
@@ -63,7 +63,7 @@ fun <A1, A2, A3, A4> NavGraphBuilder.composable(
         function: @Composable (A1, A2, A3, A4) -> Unit
 ) {
     composable(
-            screen.route,
+            screen.url,
             screen.navArguments
     ) {
         val arg1 = it.arguments?.get("a1") as A1
@@ -79,7 +79,7 @@ fun <A1, A2, A3, A4, A5> NavGraphBuilder.composable(
         function: @Composable (A1, A2, A3, A4, A5) -> Unit
 ) {
     composable(
-            screen.route,
+            screen.url,
             screen.navArguments
     ) {
         val arg1 = it.arguments?.get("a1") as A1

--- a/typednavigation/src/main/java/com/xmartlabs/typednavigation/TypedNavigation.kt
+++ b/typednavigation/src/main/java/com/xmartlabs/typednavigation/TypedNavigation.kt
@@ -6,87 +6,89 @@ import androidx.navigation.navArgument
 
 sealed class TypedNavigation {
     data class E(
-            override val name: String,
-            override val route: String = name,
-            override val navArguments: List<NamedNavArgument> = listOf()
-    ) : TypedNavigation(), TypedNavigationInterface
+        override val name: String,
+        override val url: String = "$name/",
+        override val navArguments: List<NamedNavArgument> = listOf()
+    ) : TypedNavigation(), TypedNavigationInterface0 {
+        override fun route(): String = "$name/"
+    }
 
     data class A1<A>(
-            override val name: String,
-            override val t1: NavType<A>,
-            override val route: String = "$name/{a1}",
-            override val navArguments: List<NamedNavArgument> = listOf(
-                    navArgument("a1") { type = t1 }
-            ),
+        override val name: String,
+        override val t1: NavType<A>,
+        override val url: String = "$name/{a1}",
+        override val navArguments: List<NamedNavArgument> = listOf(
+            navArgument("a1") { type = t1 }
+        ),
     ) : TypedNavigation(), TypedNavigationInterface1<A> {
-        override fun navigate(arg1: A): String = "$name/${arg1.toString()}"
+        override fun route(arg1: A): String = "$name/${arg1.toString()}"
     }
 
     data class A2<A1, A2>(
-            override val name: String,
-            override val t1: NavType<A1>,
-            override val t2: NavType<A2>,
-            override val route: String = "$name/{a1}/{a2}",
-            override val navArguments: List<NamedNavArgument> = listOf(
-                    navArgument("a1") { type = t1 },
-                    navArgument("a2") { type = t2 }
-            ),
+        override val name: String,
+        override val t1: NavType<A1>,
+        override val t2: NavType<A2>,
+        override val url: String = "$name/{a1}/{a2}",
+        override val navArguments: List<NamedNavArgument> = listOf(
+            navArgument("a1") { type = t1 },
+            navArgument("a2") { type = t2 }
+        ),
     ) : TypedNavigation(), TypedNavigationInterface2<A1, A2> {
-        override fun navigate(arg1: A1, arg2: A2): String =
-                "$name/${arg1.toString()}/${arg2.toString()}"
+        override fun route(arg1: A1, arg2: A2): String =
+            "$name/${arg1.toString()}/${arg2.toString()}"
     }
 
     data class A3<A1, A2, A3>(
-            override val name: String,
-            override val t1: NavType<A1>,
-            override val t2: NavType<A2>,
-            override val t3: NavType<A3>,
-            override val route: String = "$name/{a1}/{a2}/{a3}",
-            override val navArguments: List<NamedNavArgument> = listOf(
-                    navArgument("a1") { type = t1 },
-                    navArgument("a2") { type = t2 },
-                    navArgument("a3") { type = t3 },
-            ),
+        override val name: String,
+        override val t1: NavType<A1>,
+        override val t2: NavType<A2>,
+        override val t3: NavType<A3>,
+        override val url: String = "$name/{a1}/{a2}/{a3}",
+        override val navArguments: List<NamedNavArgument> = listOf(
+            navArgument("a1") { type = t1 },
+            navArgument("a2") { type = t2 },
+            navArgument("a3") { type = t3 },
+        ),
     ) : TypedNavigation(), TypedNavigationInterface3<A1, A2, A3> {
-        override fun navigate(arg1: A1, arg2: A2, arg3: A3): String =
-                "$name/${arg1.toString()}/${arg2.toString()}/${arg3.toString()}"
+        override fun route(arg1: A1, arg2: A2, arg3: A3): String =
+            "$name/${arg1.toString()}/${arg2.toString()}/${arg3.toString()}"
     }
 
     data class A4<A1, A2, A3, A4>(
-            override val name: String,
-            override val t1: NavType<A1>,
-            override val t2: NavType<A2>,
-            override val t3: NavType<A3>,
-            override val t4: NavType<A4>,
-            override val route: String = "$name/{a1}/{a2}/{a3}/{a4}",
-            override val navArguments: List<NamedNavArgument> = listOf(
-                    navArgument("a1") { type = t1 },
-                    navArgument("a2") { type = t2 },
-                    navArgument("a3") { type = t3 },
-                    navArgument("a4") { type = t4 },
-            ),
+        override val name: String,
+        override val t1: NavType<A1>,
+        override val t2: NavType<A2>,
+        override val t3: NavType<A3>,
+        override val t4: NavType<A4>,
+        override val url: String = "$name/{a1}/{a2}/{a3}/{a4}",
+        override val navArguments: List<NamedNavArgument> = listOf(
+            navArgument("a1") { type = t1 },
+            navArgument("a2") { type = t2 },
+            navArgument("a3") { type = t3 },
+            navArgument("a4") { type = t4 },
+        ),
     ) : TypedNavigation(), TypedNavigationInterface4<A1, A2, A3, A4> {
-        override fun navigate(arg1: A1, arg2: A2, arg3: A3, arg4: A4): String =
-                "$name/${arg1.toString()}/${arg2.toString()}/${arg3.toString()}/${arg4.toString()}"
+        override fun route(arg1: A1, arg2: A2, arg3: A3, arg4: A4): String =
+            "$name/${arg1.toString()}/${arg2.toString()}/${arg3.toString()}/${arg4.toString()}"
     }
 
     data class A5<A1, A2, A3, A4, A5>(
-            override val name: String,
-            override val t1: NavType<A1>,
-            override val t2: NavType<A2>,
-            override val t3: NavType<A3>,
-            override val t4: NavType<A4>,
-            override val t5: NavType<A5>,
-            override val route: String = "$name/{a1}/{a2}/{a3}/{a4}/{a5}",
-            override val navArguments: List<NamedNavArgument> = listOf(
-                    navArgument("a1") { type = t1 },
-                    navArgument("a2") { type = t2 },
-                    navArgument("a3") { type = t3 },
-                    navArgument("a4") { type = t4 },
-                    navArgument("a5") { type = t5 },
-            ),
+        override val name: String,
+        override val t1: NavType<A1>,
+        override val t2: NavType<A2>,
+        override val t3: NavType<A3>,
+        override val t4: NavType<A4>,
+        override val t5: NavType<A5>,
+        override val url: String = "$name/{a1}/{a2}/{a3}/{a4}/{a5}",
+        override val navArguments: List<NamedNavArgument> = listOf(
+            navArgument("a1") { type = t1 },
+            navArgument("a2") { type = t2 },
+            navArgument("a3") { type = t3 },
+            navArgument("a4") { type = t4 },
+            navArgument("a5") { type = t5 },
+        ),
     ) : TypedNavigation(), TypedNavigationInterface5<A1, A2, A3, A4, A5> {
-        override fun navigate(arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5): String =
-                "$name/${arg1.toString()}/${arg2.toString()}/${arg3.toString()}/${arg4.toString()}/${arg5.toString()}"
+        override fun route(arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5): String =
+            "$name/${arg1.toString()}/${arg2.toString()}/${arg3.toString()}/${arg4.toString()}/${arg5.toString()}"
     }
 }

--- a/typednavigation/src/main/java/com/xmartlabs/typednavigation/TypedNavigationInterface.kt
+++ b/typednavigation/src/main/java/com/xmartlabs/typednavigation/TypedNavigationInterface.kt
@@ -6,21 +6,26 @@ import androidx.navigation.NavType
 
 sealed interface TypedNavigationInterface {
     val name: String
-    val route: String
+    val url: String
     val navArguments: List<NamedNavArgument>
+}
+
+interface TypedNavigationInterface0 : TypedNavigationInterface{
+
+    fun route() : String
 }
 
 interface TypedNavigationInterface1<A> : TypedNavigationInterface {
     val t1: NavType<A>
 
-    fun navigate(arg1: A): String
+    fun route(arg1: A): String
 }
 
 interface TypedNavigationInterface2<A1, A2> : TypedNavigationInterface {
     val t1: NavType<A1>
     val t2: NavType<A2>
 
-    fun navigate(arg1: A1, arg2: A2): String
+    fun route(arg1: A1, arg2: A2): String
 }
 
 interface TypedNavigationInterface3<A1, A2, A3> : TypedNavigationInterface {
@@ -28,7 +33,7 @@ interface TypedNavigationInterface3<A1, A2, A3> : TypedNavigationInterface {
     val t2: NavType<A2>
     val t3: NavType<A3>
 
-    fun navigate(arg1: A1, arg2: A2, arg3: A3): String
+    fun route(arg1: A1, arg2: A2, arg3: A3): String
 }
 
 interface TypedNavigationInterface4<A1, A2, A3, A4> : TypedNavigationInterface {
@@ -37,7 +42,7 @@ interface TypedNavigationInterface4<A1, A2, A3, A4> : TypedNavigationInterface {
     val t3: NavType<A3>
     val t4: NavType<A4>
 
-    fun navigate(arg1: A1, arg2: A2, arg3: A3, arg4: A4): String
+    fun route(arg1: A1, arg2: A2, arg3: A3, arg4: A4): String
 }
 
 interface TypedNavigationInterface5<A1, A2, A3, A4, A5> : TypedNavigationInterface {
@@ -47,5 +52,5 @@ interface TypedNavigationInterface5<A1, A2, A3, A4, A5> : TypedNavigationInterfa
     val t4: NavType<A4>
     val t5: NavType<A5>
 
-    fun navigate(arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5): String
+    fun route(arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5): String
 }


### PR DESCRIPTION
Changed `navigate()` to `route()` and `route` to `url` for more clarity.

Also added `TypedNavigationInterface0` so ` TypedNavigation.E` has a `route()` function and it's not added to the other implementations.